### PR TITLE
SPLIT_USB_DETECT prevents keyboard detection on cold boot

### DIFF
--- a/keyboards/cyboard/dactyl/config.h
+++ b/keyboards/cyboard/dactyl/config.h
@@ -91,3 +91,7 @@
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_LED GP17
 #define RP2040_BOOTLOADER_DOUBLE_TAP_RESET_TIMEOUT 1000U
+
+// https://github.com/qmk/qmk_firmware/issues/18511#issuecomment-1264604610
+// https://github.com/qmk/qmk_firmware/issues/8990#issuecomment-851055637
+#undef SPLIT_USB_DETECT

--- a/keyboards/cyboard/dactyl/keymaps/singlearc_number_row/config.h
+++ b/keyboards/cyboard/dactyl/keymaps/singlearc_number_row/config.h
@@ -8,3 +8,12 @@
 #define VIAL_UNLOCK_COMBO_COLS { 5, 6 }
 
 #define DYNAMIC_KEYMAP_LAYER_COUNT 10
+
+// -----------------------------------------------------------------------------
+// sunaku
+// -----------------------------------------------------------------------------
+
+// https://github.com/qmk/qmk_firmware/issues/18511#issuecomment-1264604610
+// https://github.com/qmk/qmk_firmware/issues/8990#issuecomment-851055637
+#undef SPLIT_USB_DETECT
+

--- a/keyboards/cyboard/dactyl/keymaps/singlearc_number_row/rules.mk
+++ b/keyboards/cyboard/dactyl/keymaps/singlearc_number_row/rules.mk
@@ -7,9 +7,3 @@ COMBO_ENABLE = yes
 KEY_OVERRIDE_ENABLE = yes
 VIALRGB_ENABLE = yes
 
-#-----------------------------------------------------------------------------
-# sunaku
-#-----------------------------------------------------------------------------
-
-# https://github.com/qmk/qmk_firmware/issues/19593#issuecomment-1387476045
-NO_USB_STARTUP_CHECK = yes

--- a/keyboards/cyboard/dactyl/keymaps/singlearc_number_row/rules.mk
+++ b/keyboards/cyboard/dactyl/keymaps/singlearc_number_row/rules.mk
@@ -6,3 +6,16 @@ TAP_DANCE_ENABLE = yes
 COMBO_ENABLE = yes
 KEY_OVERRIDE_ENABLE = yes
 VIALRGB_ENABLE = yes
+
+#-----------------------------------------------------------------------------
+# sunaku
+#-----------------------------------------------------------------------------
+
+# https://docs.qmk.fm/#/feature_caps_word?id=caps-word
+CAPS_WORD_ENABLE = yes
+
+# https://docs.qmk.fm/#/custom_quantum_functions?id=deferred-execution
+DEFERRED_EXEC_ENABLE = yes
+
+# https://github.com/qmk/qmk_firmware/issues/19593#issuecomment-1387476045
+NO_USB_STARTUP_CHECK = yes

--- a/keyboards/cyboard/dactyl/keymaps/singlearc_number_row/rules.mk
+++ b/keyboards/cyboard/dactyl/keymaps/singlearc_number_row/rules.mk
@@ -11,11 +11,5 @@ VIALRGB_ENABLE = yes
 # sunaku
 #-----------------------------------------------------------------------------
 
-# https://docs.qmk.fm/#/feature_caps_word?id=caps-word
-CAPS_WORD_ENABLE = yes
-
-# https://docs.qmk.fm/#/custom_quantum_functions?id=deferred-execution
-DEFERRED_EXEC_ENABLE = yes
-
 # https://github.com/qmk/qmk_firmware/issues/19593#issuecomment-1387476045
 NO_USB_STARTUP_CHECK = yes

--- a/keyboards/cyboard/dactyl/rules.mk
+++ b/keyboards/cyboard/dactyl/rules.mk
@@ -23,3 +23,6 @@ RGB_MATRIX_DRIVER = WS2812  # RGB matrix driver support
 
 SERIAL_DRIVER = vendor
 WS2812_DRIVER = vendor
+
+# https://github.com/qmk/qmk_firmware/issues/19593#issuecomment-1387476045
+NO_USB_STARTUP_CHECK = yes


### PR DESCRIPTION
I was having problems when turning on the computer (Mac M1) and when I needed to wake up from sleep mode.
Apparently it fixed the problem.

References:
https://github.com/sunaku/vial-qmk/tree/sunaku_remnant/keyboards/ergohaven/remnant/keymaps/sunaku

https://github.com/qmk/qmk_firmware/issues/8990

https://github.com/qmk/qmk_firmware/issues/18511
